### PR TITLE
Run template over destination

### DIFF
--- a/src/invalidate_cloudfront.coffee
+++ b/src/invalidate_cloudfront.coffee
@@ -13,7 +13,7 @@ module.exports = (grunt) ->
 
         done = @async()
         cf = new AWS.CloudFront.Client(new AWS.Config({accessKeyId:options.key, secretAccessKey: options.secret, region:options.region}))
-        filelist = ('/' + items.dest for items in this.files)
+        filelist = ('/' + grunt.template.process(items.dest) for items in this.files)
         grunt.log.writeflags(filelist, 'Invalidating '+filelist.length+' files')
 
         # List Current Invalidations

--- a/tasks/invalidate_cloudfront.js
+++ b/tasks/invalidate_cloudfront.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
       _results = [];
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         items = _ref[_i];
-        _results.push('/' + items.dest);
+        _results.push('/' + grunt.template.process(items.dest));
       }
       return _results;
     }).call(this);


### PR DESCRIPTION
This could be duplicated elsewhere in the code. Allows one to insert template tags, say versions, into the destination for invalidation.
