### PR TITLE
Allow invalidation requests containing more than 1,000 files.

### DIFF
--- a/tasks/invalidate_cloudfront.coffee
+++ b/tasks/invalidate_cloudfront.coffee
@@ -12,27 +12,54 @@ module.exports = (grunt) ->
         )
 
         done = @async()
-        cf = new AWS.CloudFront.Client(new AWS.Config({accessKeyId:options.key, secretAccessKey: options.secret, region:options.region}))
-        filelist = ('/' + encodeURI(grunt.template.process(items.dest)) for items in this.files)
-        grunt.log.writeflags(filelist, 'Invalidating '+filelist.length+' files')
+        filelist = []
 
-        # List Current Invalidations
-        cf.listInvalidations { DistributionId: options.distribution }, (err, invalidations) ->
-            grunt.fail.fatal(err) if err
-            completed = (items.Status for items in invalidations.Items when items.Status is 'Completed')
-            grunt.log.subhead(completed.length + ' Completed Invalidations on: ' + options.distribution)
+        checkForCompletion = () ->
+            cf.listInvalidations { DistributionId: options.distribution }, (err, invalidations) ->
+                grunt.fail.fatal(err) if err
+                in_progress = invalidations.Items.length - (items.Status for items in invalidations.Items when items.Status is 'Completed').length
+                if in_progress < 3
+                    invalidateBatch()
+                else
+                    grunt.log.writeln('Waiting due to ' + in_progress + ' running invalidations')
+                    setTimeout(checkForCompletion, 30000)
 
+        invalidateBatch = () ->
+            batch = filelist[0..999]
+            filelist = filelist[1000..]
+
+            grunt.log.subhead('Creating invalidation for ' + batch.length + ' files')
             # Create Invalidation params
             params =
                 DistributionId: options.distribution
                 InvalidationBatch:
                     CallerReference: '' + +new Date
                     Paths:
-                        Quantity: filelist.length
-                        Items: filelist
+                        Quantity: batch.length
+                        Items: batch
 
 
             cf.createInvalidation params, (err, data) ->
                 grunt.fail.fatal(err) if err
-                grunt.log.subhead('Invalidation created at ' + data.Location)
-                done(true)
+                grunt.log.writeln('Invalidation created at ' + data.Location)
+                if filelist.length > 0
+                    grunt.log.writeln(filelist.length + ' files remaining.')
+                    checkForCompletion()
+                else
+                    done(true)
+                        
+        cf = new AWS.CloudFront(new AWS.Config({accessKeyId:options.key, secretAccessKey: options.secret, region:options.region}))
+        filelist = ('/' + encodeURI(grunt.template.process(items.dest)) for items in this.files)
+        grunt.log.writeflags(filelist, 'Invalidating '+filelist.length+' files')
+
+        # List Current Invalidations
+        cf.listInvalidations { DistributionId: options.distribution }, (err, invalidations) ->
+            grunt.fail.fatal(err) if err
+            completed = (items.Status for items in invalidations.Items when items.Status is 'Completed').length
+            in_progress = invalidations.Items.length - completed
+            grunt.log.subhead(completed + ' Completed and ' + in_progress + ' In Progress invalidations on: ' + options.distribution)
+
+            if in_progress < 3
+                invalidateBatch()
+            else
+                checkForCompletion()


### PR DESCRIPTION
Currently EC2 doesn't allow you to have more than 1,000 requests per invalidation or have more than three invalidation requests running at once. This causes problems when you're dealing with large numbers of files.

This patch batches up the files into groups of 1,000 and only allows three to be submitted at once.
