### PR TITLE
fix encodeURI to handle apostrophes in filenames

### DIFF
--- a/tasks/invalidate_cloudfront.coffee
+++ b/tasks/invalidate_cloudfront.coffee
@@ -3,6 +3,9 @@ module.exports = (grunt) ->
     _ = grunt.util._
     AWS = require 'aws-sdk'
 
+    rfc3986EncodeURI = (str) ->
+      encodeURI(str).replace /[!'()*]/g, escape
+
     grunt.registerMultiTask "invalidate_cloudfront", "Invalidates Cloudfront files", ->
         options = @options(
             key: '',
@@ -47,9 +50,9 @@ module.exports = (grunt) ->
                     checkForCompletion()
                 else
                     done(true)
-                        
+
         cf = new AWS.CloudFront(new AWS.Config({accessKeyId:options.key, secretAccessKey: options.secret, region:options.region}))
-        filelist = ('/' + encodeURI(grunt.template.process(items.dest)) for items in this.files)
+        filelist = ('/' + rfc3986EncodeURI(grunt.template.process(items.dest)) for items in this.files)
         grunt.log.writeflags(filelist, 'Invalidating '+filelist.length+' files')
 
         # List Current Invalidations


### PR DESCRIPTION
Files that have apostrophes make the list for invalidation very unhappy.  This should fix that by using the `escape` method on those left over strange characters.

Tests did not pass on the master branch and I'm not sure where I should be adding tests.   I am using this in a current project, with great success.

