### PR TITLE
Jpges http options

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "email": "steffen@mllrsohn.com"
   },
   "repository": {
-    "type": "https",
-    "url": "https://github.com/jpges/grunt-invalidate-cloudfront.git"
+    "type": "git",
+    "url": "git://github.com/jpges/grunt-invalidate-cloudfront.git"
   },
   "bugs": {
     "url": "https://github.com/jpges/grunt-invalidate-cloudfront/issues"

--- a/package.json
+++ b/package.json
@@ -2,17 +2,17 @@
   "name": "grunt-invalidate-cloudfront",
   "description": "Sends a invalidation request to amazon cloudfront",
   "version": "0.1.6",
-  "homepage": "https://github.com/mllrsohn/grunt-invalidate-cloudfront",
+  "homepage": "https://github.com/jpges/grunt-invalidate-cloudfront",
   "author": {
     "name": "Steffen",
     "email": "steffen@mllrsohn.com"
   },
   "repository": {
-    "type": "git",
-    "url": "git://github.com/mllrsohn/grunt-invalidate-cloudfront.git"
+    "type": "https",
+    "url": "https://github.com/jpges/grunt-invalidate-cloudfront.git"
   },
   "bugs": {
-    "url": "https://github.com/mllrsohn/grunt-invalidate-cloudfront/issues"
+    "url": "https://github.com/jpges/grunt-invalidate-cloudfront/issues"
   },
   "licenses": [
     {

--- a/package.json
+++ b/package.json
@@ -2,17 +2,17 @@
   "name": "grunt-invalidate-cloudfront",
   "description": "Sends a invalidation request to amazon cloudfront",
   "version": "0.1.6",
-  "homepage": "https://github.com/jpges/grunt-invalidate-cloudfront",
+  "homepage": "https://github.com/mllrsohn/grunt-invalidate-cloudfront",
   "author": {
     "name": "Steffen",
     "email": "steffen@mllrsohn.com"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/jpges/grunt-invalidate-cloudfront.git"
+    "url": "git://github.com/mllrsohn/grunt-invalidate-cloudfront.git"
   },
   "bugs": {
-    "url": "https://github.com/jpges/grunt-invalidate-cloudfront/issues"
+    "url": "https://github.com/mllrsohn/grunt-invalidate-cloudfront/issues"
   },
   "licenses": [
     {

--- a/tasks/invalidate_cloudfront.coffee
+++ b/tasks/invalidate_cloudfront.coffee
@@ -10,8 +10,9 @@ module.exports = (grunt) ->
         options = @options(
             key: '',
             secret: '',
-            region: 'eu-west-1'
-            distribution: ''
+            region: 'eu-west-1',
+            distribution: '',
+            httpOptions: {}
         )
 
         done = @async()
@@ -51,7 +52,7 @@ module.exports = (grunt) ->
                 else
                     done(true)
 
-        cf = new AWS.CloudFront(new AWS.Config({accessKeyId:options.key, secretAccessKey: options.secret, region:options.region}))
+        cf = new AWS.CloudFront(new AWS.Config({accessKeyId:options.key, secretAccessKey: options.secret, region:options.region, httpOptions:options.httpOptions}))
         filelist = ('/' + rfc3986EncodeURI(grunt.template.process(items.dest)) for items in this.files)
         grunt.log.writeflags(filelist, 'Invalidating '+filelist.length+' files')
 


### PR DESCRIPTION
Mainly, I have updated invalidate_cloudfront.coffee in order to be able to indicate the proxy must be used to send invalidation request to AWS Cloudfront.

This change is compatible with previous versions. If you don't indicate proxy, this change hasn't effects.

Updates on package.json are stupid, they are useless and finally they don't include any change. 
