### PR TITLE
Update to be able to indicate proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-invalidate-cloudfront",
   "description": "Sends a invalidation request to amazon cloudfront",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "homepage": "https://github.com/mllrsohn/grunt-invalidate-cloudfront",
   "author": {
     "name": "Steffen",

--- a/tasks/invalidate_cloudfront.coffee
+++ b/tasks/invalidate_cloudfront.coffee
@@ -10,8 +10,9 @@ module.exports = (grunt) ->
         options = @options(
             key: '',
             secret: '',
-            region: 'eu-west-1'
-            distribution: ''
+            region: 'eu-west-1',
+            distribution: '',
+            httpOptions: {}
         )
 
         done = @async()
@@ -51,7 +52,7 @@ module.exports = (grunt) ->
                 else
                     done(true)
 
-        cf = new AWS.CloudFront(new AWS.Config({accessKeyId:options.key, secretAccessKey: options.secret, region:options.region}))
+        cf = new AWS.CloudFront(new AWS.Config({accessKeyId:options.key, secretAccessKey: options.secret, region:options.region, httpOptions:options.httpOptions}))
         filelist = ('/' + rfc3986EncodeURI(grunt.template.process(items.dest)) for items in this.files)
         grunt.log.writeflags(filelist, 'Invalidating '+filelist.length+' files')
 


### PR DESCRIPTION
Mainly, I have updated invalidate_cloudfront.coffee in order to be able to indicate the proxy must be used to send invalidation request to AWS Cloudfront.

This change is compatible with previous versions. If you don't indicate proxy, this change hasn't effects.

In package.json I have updated new release number to publish.